### PR TITLE
Fix issue #3

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -30,18 +30,21 @@ class App extends Component {
   }
 
   addItem(item) {
-    let newData = Object.assign(this.state.data.items);
-    newData.push(item);
-    this.setState(newData);
+    let newItems = Object.assign([], this.state.data.items);
+    newItems.push(item);
+
+    let newState = Object.assign({}, this.state);
+    newState.data.items = Object.assign([], newItems);
+    this.setState(newState);
   }
 
   updateItem(item) {
-    console.log("i'm called!");
-    let newData = Object.assign(this.state.data.items)
-    newData[item.key] = item;
-    // newData.push(item);
-    console.log(newData)
-    this.setState(newData);
+    let newItems = Object.assign([], this.state.data.items)
+    newItems[item.key] = item;
+
+    let newState = Object.assign({}, this.state);
+    newState.data.items = Object.assign([], newItems);
+    this.setState(newState);
   }
 
   render() {

--- a/src/App.js
+++ b/src/App.js
@@ -117,7 +117,10 @@ class App extends Component {
                 ? "Add a new item"
                 : "Edit an item"}
               modalItem={this.state.modalItem}
-              onHide={()=> this.setState({'showModal':'false'})}
+              onHide={()=> this.setState({
+                'modalItem': {},
+                'showModal':'false'
+               })}
               onSave={this.state.modalAction === 'add' 
                 ? this.addItem
                 : this.updateItem}


### PR DESCRIPTION
1. Keeps the state mutable when adding or editing an item.
Since it wasn't the case before, each items where added as a state
property. However, the code was working because we were directly
mutating the state.

2. Fixes the bug that made the modal displays previous item information.
- Resets the modalItem property in the app state to be sure there is no
data when we hide the modal.
